### PR TITLE
Fix issue 23: kek_lr and tqdm (incorrect)

### DIFF
--- a/kekas/callbacks.py
+++ b/kekas/callbacks.py
@@ -355,6 +355,8 @@ class ProgressBarCallback(Callback):
             state.core.pbar.close()
         elif state.core.mode == "test":
             state.core.pbar.close()
+        elif state.core.mode == "train":
+            state.core.pbar.close()
 
 
 class MetricsCallback(Callback):


### PR DESCRIPTION
As lerning rate finder uses kek() with skip_val=True,
so close the tqdm after train epoch is ended too.