### PR TITLE
Fix issue_23 version 2

### DIFF
--- a/kekas/keker.py
+++ b/kekas/keker.py
@@ -428,7 +428,7 @@ class Keker:
             self.kek(
                 lr=init_lr,
                 epochs=n_epochs,
-                skip_val=True,
+                skip_val=False,
                 logdir=logdir,
                 opt=opt,
                 opt_params=opt_params,


### PR DESCRIPTION
Just change im kek_lr parameter.

skip_val=True --> skip_val=Flase

So progress bar closed in ProgressBarCallback.on_epoch_end.
